### PR TITLE
修正s.name和HEADER_SEARCH_PATHS

### DIFF
--- a/ios/RCTWeiBo.podspec
+++ b/ios/RCTWeiBo.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "RCTWeibo"
+  s.name         = "RCTWeiBo"
   s.version      = "0.0.1"
   s.summary      = "React-Native(iOS/Android) functionalities include Weibo Login"
 

--- a/ios/RCTWeiBo.xcodeproj/project.pbxproj
+++ b/ios/RCTWeiBo.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../react-native/Libraries/**",
 					"$(BUILT_PRODUCTS_DIR)/include/**",
@@ -252,6 +253,7 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../react-native/Libraries/**",
 					"$(BUILT_PRODUCTS_DIR)/include/**",


### PR DESCRIPTION
如果不修正 s.name ，会产生两个.o文件（RCTWeiBo.o RCTWeibo.o），会报错 duplicate symbol_ 。
如果不修正 HEADER_SEARCH_PATHS ，react-native run-ios 就出错了 ，会报错'React/RCTBridgeModule.h' file not found